### PR TITLE
Forced colors support

### DIFF
--- a/components/ExperienceCard.vue
+++ b/components/ExperienceCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="desktop:w-7/12 shadow-card rounded-lg dark:shadow-none dark:border-4 dark:border-grey-400"
+    class="desktop:w-7/12 shadow-card rounded-lg forced-colors:border-4 forced-colors:border-systemColors-ButtonBorder dark:shadow-none dark:border-4 dark:border-grey-400"
     :class="{
       'desktop:ml-auto': !isOdd,
       'pb-4': isExpanded,
@@ -43,7 +43,7 @@
             stroke-linejoin="round"
             stroke-width="8"
             width="50"
-            class="stroke-grey-500 dark:stroke-grey-300 group-hover:stroke-green-highlight dark:group-hover:stroke-greenDarkMode-base group-focus:stroke-green-highlight dark:group-focus:stroke-greenDarkMode-base transition-all motion-reduce:transition-none duration-300 ease-in-out"
+            class="stroke-grey-500 forced-colors:stroke-systemColors-ButtonText dark:stroke-grey-300 group-hover:stroke-green-highlight forced-colors:group-hover:stroke-systemColors-Highlight dark:group-hover:stroke-greenDarkMode-base group-focus:stroke-green-highlight forced-colors:group-focus:stroke-systemColors-Highlight dark:group-focus:stroke-greenDarkMode-base transition-all motion-reduce:transition-none duration-300 ease-in-out"
             :class="{ 'rotate-180': isExpanded }"
             aria-hidden="true"
           >
@@ -69,7 +69,7 @@
               stroke-linecap="round"
               stroke-linejoin="round"
               stroke-width="6"
-              class="stroke-green-highlight dark:stroke-greenDarkMode-base h-7 tablet:h-8"
+              class="stroke-green-highlight forced-colors:stroke-systemColors-AccentColor dark:stroke-greenDarkMode-base h-7 tablet:h-8"
               role="img"
             >
               <title>Location Icon</title>

--- a/components/ExperienceCard.vue
+++ b/components/ExperienceCard.vue
@@ -69,7 +69,7 @@
               stroke-linecap="round"
               stroke-linejoin="round"
               stroke-width="6"
-              class="stroke-green-highlight forced-colors:stroke-systemColors-AccentColor dark:stroke-greenDarkMode-base h-7 tablet:h-8"
+              class="stroke-green-highlight forced-colors:stroke-systemColors-Highlight dark:stroke-greenDarkMode-base h-7 tablet:h-8"
               role="img"
             >
               <title>Location Icon</title>

--- a/components/ExternalLink.vue
+++ b/components/ExternalLink.vue
@@ -3,7 +3,7 @@
     :href="url"
     target="_blank"
     rel="noreferrer noopener"
-    class="font-bold tracking-wide text-blue-base hover:text-blue-highlight hover:underline focus:text-blue-highlight focus:underline dark:text-blueDarkMode-base dark:hover:text-blueDarkMode-highlight dark:focus:text-blueDarkMode-highlight"
+    class="font-bold tracking-wide text-blue-base forced-colors:text-systemColors-LinkText forced-colors:hover:text-systemColors-LinkText forced-colors:focus:text-systemColors-LinkText hover:text-blue-highlight hover:underline focus:text-blue-highlight focus:underline dark:text-blueDarkMode-base dark:hover:text-blueDarkMode-highlight dark:focus:text-blueDarkMode-highlight"
   >
     <slot /><span class="sr-only">Opens in a new window.</span>
   </a>

--- a/components/InternalLink.vue
+++ b/components/InternalLink.vue
@@ -1,7 +1,7 @@
 <template>
   <a
     :href="url"
-    class="font-bold tracking-wide text-green-base hover:text-green-highlight hover:underline focus:text-green-highlight focus:underline dark:text-greenDarkMode-base dark:hover:text-greenDarkMode-highlight dark:focus:text-greenDarkMode-highlight"
+    class="font-bold tracking-wide text-green-base forced-colors:text-systemColors-AccentColor forced-colors:hover:text-systemColors-AccentColor forced-colors:focus:text-systemColors-AccentColor hover:text-green-highlight hover:underline focus:text-green-highlight focus:underline dark:text-greenDarkMode-base dark:hover:text-greenDarkMode-highlight dark:focus:text-greenDarkMode-highlight"
     >{{ text }}</a
   >
 </template>

--- a/components/InternalLink.vue
+++ b/components/InternalLink.vue
@@ -1,7 +1,7 @@
 <template>
   <a
     :href="url"
-    class="font-bold tracking-wide text-green-base forced-colors:text-systemColors-AccentColor forced-colors:hover:text-systemColors-AccentColor forced-colors:focus:text-systemColors-AccentColor hover:text-green-highlight hover:underline focus:text-green-highlight focus:underline dark:text-greenDarkMode-base dark:hover:text-greenDarkMode-highlight dark:focus:text-greenDarkMode-highlight"
+    class="font-bold tracking-wide text-green-base forced-colors:text-systemColors-Highlight forced-colors:hover:text-systemColors-Highlight forced-colors:focus:text-systemColors-Highlight hover:text-green-highlight hover:underline focus:text-green-highlight focus:underline dark:text-greenDarkMode-base dark:hover:text-greenDarkMode-highlight dark:focus:text-greenDarkMode-highlight"
     >{{ text }}</a
   >
 </template>

--- a/components/NavLink.vue
+++ b/components/NavLink.vue
@@ -1,8 +1,9 @@
 <template>
   <a
-    class="font-bold transition duration-200 ease-in-out hover:text-green-highlightLarge dark:hover:text-greenDarkMode-highlightLarge hover:underline focus:text-green-highlightLarge dark:focus:text-greenDarkMode-highlightLarge focus:underline tablet:text-xl tablet:tracking-wider"
+    class="font-bold transition duration-200 ease-in-out forced-colors:transition-none forced-colors:text-systemColors-LinkText forced-colors:hover:text-systemColors-LinkText forced-colors:focus:text-systemColors-LinkText hover:text-green-highlightLarge dark:hover:text-greenDarkMode-highlightLarge hover:underline focus:text-green-highlightLarge dark:focus:text-greenDarkMode-highlightLarge focus:underline tablet:text-xl tablet:tracking-wider"
     :class="{
-      'text-green-baseLarge dark:text-greenDarkMode-baseLarge': isCurrentPage,
+      'text-green-baseLarge forced-colors:text-systemColors-AccentColor dark:text-greenDarkMode-baseLarge':
+        isCurrentPage,
     }"
     :href="url"
   >

--- a/components/NavLink.vue
+++ b/components/NavLink.vue
@@ -2,7 +2,7 @@
   <a
     class="font-bold transition duration-200 ease-in-out forced-colors:transition-none forced-colors:text-systemColors-LinkText forced-colors:hover:text-systemColors-LinkText forced-colors:focus:text-systemColors-LinkText hover:text-green-highlightLarge dark:hover:text-greenDarkMode-highlightLarge hover:underline focus:text-green-highlightLarge dark:focus:text-greenDarkMode-highlightLarge focus:underline tablet:text-xl tablet:tracking-wider"
     :class="{
-      'text-green-baseLarge forced-colors:text-systemColors-AccentColor dark:text-greenDarkMode-baseLarge':
+      'text-green-baseLarge forced-colors:text-systemColors-Highlight dark:text-greenDarkMode-baseLarge':
         isCurrentPage,
     }"
     :href="url"

--- a/components/ProjectCard.vue
+++ b/components/ProjectCard.vue
@@ -1,6 +1,6 @@
 <template>
   <section
-    class="relative overflow-hidden rounded-lg shadow-card dark:shadow-none dark:border-4 dark:border-grey-400"
+    class="relative overflow-hidden rounded-lg shadow-card forced-colors:border-4 forced-colors:border-systemColors-ButtonBorder dark:shadow-none dark:border-4 dark:border-grey-400"
   >
     <ExternalLink
       :url="link"
@@ -8,7 +8,7 @@
     >
       <img :src="imgSrc" :alt="imgAlt" class="h-full w-full" />
       <div
-        class="min-h-1/6 w-full absolute bottom-0 flex flex-col justify-center gap-2 bg-white dark:bg-zinc-800 group-hover:bg-grey-50 group-focus:bg-grey-50 group-active:bg-grey-100 dark:group-hover:bg-zinc-700 dark:group-focus:bg-zinc-700 dark:group-active:bg-zinc-600 px-4 pt-2 pb-8 tablet:px-8 tablet:pt-3 tablet:pb-10"
+        class="min-h-1/6 w-full absolute bottom-0 flex flex-col justify-center gap-2 bg-white dark:bg-zinc-800 forced-colors:group-hover:text-systemColors-SelectedItemText forced-colors:group-focus:text-systemColors-SelectedItemText forced-colors:group-active:text-systemColors-SelectedItemText forced-colors:group-hover:bg-systemColors-SelectedItem forced-colors:group-focus:bg-systemColors-SelectedItem forced-colors:group-active:bg-systemColors-SelectedItem group-hover:bg-grey-50 group-focus:bg-grey-50 group-active:bg-grey-100 dark:group-hover:bg-zinc-700 dark:group-focus:bg-zinc-700 dark:group-active:bg-zinc-600 px-4 pt-2 pb-8 tablet:px-8 tablet:pt-3 tablet:pb-10"
       >
         <h2
           class="text-xl tracking-widest text-green-baseLarge dark:text-greenDarkMode-baseLarge tablet:text-2xl desktop:text-4xl"
@@ -24,7 +24,7 @@
           <span
             v-for="(tag, index) in tags"
             :key="index"
-            class="rounded-md bg-primary-base dark:bg-primaryDarkMode-base font-normal dark:font-bold tracking-wide p-2 align-middle leading-4 text-white dark:text-grey tablet:text-lg tablet:leading-4 desktop:text-xl"
+            class="rounded-md bg-primary-base forced-colors:border-2 forced-colors:border-systemColors-ButtonBorder dark:bg-primaryDarkMode-base font-normal forced-colors:group-hover:text-systemColors-SelectedItemText forced-colors:group-focus:text-systemColors-SelectedItemText forced-colors:group-active:text-systemColors-SelectedItemText forced-colors:group-hover:bg-systemColors-SelectedItem forced-colors:group-focus:bg-systemColors-SelectedItem forced-colors:group-active:bg-systemColors-SelectedItem dark:font-bold tracking-wide p-2 align-middle leading-4 text-white dark:text-grey tablet:text-lg tablet:leading-4 desktop:text-xl"
             >{{ tag }}</span
           >
         </div>

--- a/components/PromotionCard.vue
+++ b/components/PromotionCard.vue
@@ -1,6 +1,6 @@
 <template>
   <section
-    class="rounded-lg px-4 pb-4 shadow-card dark:shadow-none dark:border-2 dark:border-grey-400"
+    class="rounded-lg px-4 pb-4 shadow-card forced-colors:border-2 forced-colors:border-systemColors-ButtonBorder dark:shadow-none dark:border-2 dark:border-grey-400"
   >
     <div
       class="border-b-2 border-grey-400 dark:border-grey-200 y-2 px-2 tablet:py-3 tablet:px-4"

--- a/components/ThemeSwitcher.vue
+++ b/components/ThemeSwitcher.vue
@@ -25,8 +25,11 @@
     >
       <label
         for="system"
-        class="py-2 pl-3 pr-6 rounded-t-lg hover:bg-grey-50 focus:bg-grey-50 active:bg-grey-100 dark:hover:bg-zinc-700 dark:focus:bg-zinc-700 dark:active:bg-zinc-600"
-        :class="{ 'bg-grey-50 dark:bg-zinc-700': colourScheme === 'system' }"
+        class="py-2 pl-3 pr-6 rounded-t-lg hover:bg-grey-50 active:bg-grey-100 forced-colors:hover:border-2 forced-colors:hover:m-[6px] forced-colors:hover:py-0 forced-colors:hover:pl-1 forced-colors:hover:pr-4 dark:hover:bg-zinc-700 dark:active:bg-zinc-600"
+        :class="{
+          'bg-grey-50 forced-colors:border-2 forced-colors:m-[6px] forced-colors:py-0 forced-colors:pl-1 forced-colors:pr-4 dark:bg-zinc-700':
+            activeElement === 'system',
+        }"
       >
         <input
           type="radio"
@@ -35,6 +38,8 @@
           value="system"
           @input="setColourScheme('system')"
           :checked="colourScheme === 'system'"
+          @focus="activeElement = 'system'"
+          @blur="activeElement = ''"
           class="appearance-none peer"
         />
         <svg
@@ -53,8 +58,11 @@
       </label>
       <label
         for="light"
-        class="py-2 pl-3 pr-6 hover:bg-grey-50 focus:bg-grey-50 active:bg-grey-100 dark:hover:bg-zinc-700 dark:focus:bg-zinc-700 dark:active:bg-zinc-600"
-        :class="{ 'bg-grey-50 dark:bg-zinc-700': colourScheme === 'light' }"
+        class="py-2 pl-3 pr-6 rounded-lg hover:bg-grey-50 active:bg-grey-100 forced-colors:hover:border-2 forced-colors:hover:m-[6px] forced-colors:hover:py-0 forced-colors:hover:pl-1 forced-colors:hover:pr-4 dark:hover:bg-zinc-700 dark:active:bg-zinc-600"
+        :class="{
+          'bg-grey-50 forced-colors:border-2 forced-colors:m-[6px] forced-colors:py-0 forced-colors:pl-1 forced-colors:pr-4 dark:bg-zinc-700':
+            activeElement === 'light',
+        }"
       >
         <input
           type="radio"
@@ -63,13 +71,15 @@
           value="light"
           @input="setColourScheme('light')"
           :checked="colourScheme === 'light'"
+          @focus="activeElement = 'light'"
+          @blur="activeElement = ''"
           class="appearance-none peer"
         />
         <svg
           width="35"
           height="35"
           :viewBox="themeIconViewboxList['light']"
-          class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText forced-colors:peer-checked:fill-systemColors-AccentColor dark:fill-white peer-checked:fill-green-highlight inline"
+          class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText forced-colors:peer-checked:fill-systemColors-AccentColor dark:fill-white peer-checked:fill-green-highlight dark:peer-checked:fill-greenDarkMode-highlight inline"
         >
           <use xlink:href="/icons/lightThemeIcon.svg#svg5"></use>
         </svg>
@@ -81,8 +91,11 @@
       </label>
       <label
         for="dark"
-        class="py-2 pl-3 pr-6 rounded-b-lg hover:bg-grey-50 focus:bg-grey-50 active:bg-grey-100 dark:hover:bg-zinc-700 dark:focus:bg-zinc-700 dark:active:bg-zinc-600"
-        :class="{ 'bg-grey-50 dark:bg-zinc-700': colourScheme === 'dark' }"
+        class="py-2 pl-3 pr-6 rounded-b-lg hover:bg-grey-50 active:bg-grey-100 forced-colors:hover:border-2 forced-colors:hover:m-[6px] forced-colors:hover:py-0 forced-colors:hover:pl-1 forced-colors:hover:pr-4 dark:hover:bg-zinc-700 dark:active:bg-zinc-600"
+        :class="{
+          'bg-grey-50 forced-colors:border-2 forced-colors:m-[6px] forced-colors:py-0 forced-colors:pl-1 forced-colors:pr-4 dark:bg-zinc-700':
+            activeElement === 'dark',
+        }"
       >
         <input
           type="radio"
@@ -91,13 +104,15 @@
           value="dark"
           @input="setColourScheme('dark')"
           :checked="colourScheme === 'dark'"
+          @focus="activeElement = 'dark'"
+          @blur="activeElement = ''"
           class="appearance-none peer"
         />
         <svg
           width="35"
           height="35"
           :viewBox="themeIconViewboxList['dark']"
-          class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText forced-colors:peer-checked:fill-systemColors-AccentColor dark:fill-white dark:peer-checked:fill-greenDarkMode-base inline"
+          class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText forced-colors:peer-checked:fill-systemColors-AccentColor dark:fill-white peer-checked:fill-green-highlight dark:peer-checked:fill-greenDarkMode-highlight inline"
         >
           <use xlink:href="/icons/darkThemeIcon.svg#svg5"></use>
         </svg>
@@ -214,6 +229,7 @@ export default {
         dark: '-50 -50 388.37381 395.4344',
       },
       isExpanded: false,
+      activeElement: '',
     };
   },
 };

--- a/components/ThemeSwitcher.vue
+++ b/components/ThemeSwitcher.vue
@@ -117,10 +117,23 @@ export default {
   mounted() {
     this.setColourScheme();
 
+    // Don't worry about the color-scheme if high-contrast mode is active
+    window.matchMedia('(forced-colors: active)').onchange = (e) => {
+      this.isForcedColorsActive = e.matches;
+
+      if (this.isForcedColorsActive) {
+        document.documentElement.classList.remove('dark');
+      } else {
+        this.setColourScheme();
+      }
+    };
+
     // Add event listener to handle OS preference switching
     // NOTE: I know I'm only using one of these and that it will persist through the app's lifetime, so no need to remove listener
     window.matchMedia('(prefers-color-scheme: dark)').onchange = (e) => {
       if ('colourScheme' in localStorage) return; // only handle OS preference
+
+      if (this.isForcedColorsActive) return; // don't handle theme if WHCM is on
 
       if (e.matches) {
         document.documentElement.classList.add('dark');
@@ -174,6 +187,8 @@ export default {
         this.colourScheme = newColourScheme;
       }
 
+      if (this.isForcedColorsActive) return; // don't change theme if WHCM is on
+
       // On page load or when changing colour schemes, best to add inline in `head` to avoid FOUC
       if (
         localStorage.colourScheme === 'dark' ||
@@ -188,6 +203,8 @@ export default {
   },
   data() {
     return {
+      isForcedColorsActive: window.matchMedia('(forced-colors: active)')
+        .matches,
       colourScheme: localStorage.colourScheme
         ? localStorage.colourScheme
         : 'system',

--- a/components/ThemeSwitcher.vue
+++ b/components/ThemeSwitcher.vue
@@ -11,7 +11,7 @@
         height="48"
         width="48"
         :viewBox="themeIconViewboxList[colourScheme]"
-        class="stroke-none fill-grey dark:fill-white"
+        class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText dark:fill-white"
       >
         <title>{{ colourScheme }} theme icon</title>
         <use :xlink:href="`/icons/${colourScheme}ThemeIcon.svg#svg5`"></use>
@@ -21,7 +21,7 @@
       ref="themeSwitcher"
       id="themeSwitcher"
       v-if="isExpanded"
-      class="absolute mt-4 z-10 right-5 flex flex-col shadow-card rounded-lg dark:shadow-none dark:border-2 dark:border-white bg-white dark:bg-zinc-800 opacity-100"
+      class="absolute mt-4 z-10 right-5 flex flex-col shadow-card rounded-lg forced-colors:border-2 forced-colors:border-systemColors-ButtonBorder dark:shadow-none dark:border-2 dark:border-white bg-white dark:bg-zinc-800 opacity-100"
     >
       <label
         for="system"
@@ -41,12 +41,12 @@
           width="35"
           height="35"
           :viewBox="themeIconViewboxList['system']"
-          class="stroke-none fill-grey dark:fill-white peer-checked:fill-green-highlight dark:peer-checked:fill-greenDarkMode-highlight inline"
+          class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText forced-colors:peer-checked:fill-systemColors-AccentColor dark:fill-white peer-checked:fill-green-highlight dark:peer-checked:fill-greenDarkMode-highlight inline"
         >
           <use xlink:href="/icons/systemThemeIcon.svg#svg5"></use>
         </svg>
         <span
-          class="pl-1 font-bold peer-checked:text-green-base dark:peer-checked:text-greenDarkMode-base"
+          class="pl-1 font-bold forced-colors:peer-checked:text-systemColors-AccentColor peer-checked:text-green-base dark:peer-checked:text-greenDarkMode-base"
         >
           System
         </span>
@@ -69,12 +69,12 @@
           width="35"
           height="35"
           :viewBox="themeIconViewboxList['light']"
-          class="stroke-none fill-grey dark:fill-white peer-checked:fill-green-highlight inline"
+          class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText forced-colors:peer-checked:fill-systemColors-AccentColor dark:fill-white peer-checked:fill-green-highlight inline"
         >
           <use xlink:href="/icons/lightThemeIcon.svg#svg5"></use>
         </svg>
         <span
-          class="pl-1 font-bold peer-checked:text-green-base dark:peer-checked:text-greenDarkMode-base"
+          class="pl-1 font-bold forced-colors:peer-checked:text-systemColors-AccentColor peer-checked:text-green-base dark:peer-checked:text-greenDarkMode-base"
         >
           Light
         </span>
@@ -97,12 +97,12 @@
           width="35"
           height="35"
           :viewBox="themeIconViewboxList['dark']"
-          class="stroke-none fill-grey dark:fill-white dark:peer-checked:fill-greenDarkMode-base inline"
+          class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText forced-colors:peer-checked:fill-systemColors-AccentColor dark:fill-white dark:peer-checked:fill-greenDarkMode-base inline"
         >
           <use xlink:href="/icons/darkThemeIcon.svg#svg5"></use>
         </svg>
         <span
-          class="pl-1 font-bold peer-checked:text-green-base dark:peer-checked:text-greenDarkMode-base"
+          class="pl-1 font-bold forced-colors:peer-checked:text-systemColors-AccentColor peer-checked:text-green-base dark:peer-checked:text-greenDarkMode-base"
         >
           Dark
         </span>

--- a/components/ThemeSwitcher.vue
+++ b/components/ThemeSwitcher.vue
@@ -46,12 +46,12 @@
           width="35"
           height="35"
           :viewBox="themeIconViewboxList['system']"
-          class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText forced-colors:peer-checked:fill-systemColors-AccentColor dark:fill-white peer-checked:fill-green-highlight dark:peer-checked:fill-greenDarkMode-highlight inline"
+          class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText forced-colors:peer-checked:fill-systemColors-Highlight dark:fill-white peer-checked:fill-green-highlight dark:peer-checked:fill-greenDarkMode-highlight inline"
         >
           <use xlink:href="/icons/systemThemeIcon.svg#svg5"></use>
         </svg>
         <span
-          class="pl-1 font-bold forced-colors:peer-checked:text-systemColors-AccentColor peer-checked:text-green-base dark:peer-checked:text-greenDarkMode-base"
+          class="pl-1 font-bold forced-colors:peer-checked:text-systemColors-Highlight peer-checked:text-green-base dark:peer-checked:text-greenDarkMode-base"
         >
           System
         </span>
@@ -79,12 +79,12 @@
           width="35"
           height="35"
           :viewBox="themeIconViewboxList['light']"
-          class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText forced-colors:peer-checked:fill-systemColors-AccentColor dark:fill-white peer-checked:fill-green-highlight dark:peer-checked:fill-greenDarkMode-highlight inline"
+          class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText forced-colors:peer-checked:fill-systemColors-Highlight dark:fill-white peer-checked:fill-green-highlight dark:peer-checked:fill-greenDarkMode-highlight inline"
         >
           <use xlink:href="/icons/lightThemeIcon.svg#svg5"></use>
         </svg>
         <span
-          class="pl-1 font-bold forced-colors:peer-checked:text-systemColors-AccentColor peer-checked:text-green-base dark:peer-checked:text-greenDarkMode-base"
+          class="pl-1 font-bold forced-colors:peer-checked:text-systemColors-Highlight peer-checked:text-green-base dark:peer-checked:text-greenDarkMode-base"
         >
           Light
         </span>
@@ -112,12 +112,12 @@
           width="35"
           height="35"
           :viewBox="themeIconViewboxList['dark']"
-          class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText forced-colors:peer-checked:fill-systemColors-AccentColor dark:fill-white peer-checked:fill-green-highlight dark:peer-checked:fill-greenDarkMode-highlight inline"
+          class="stroke-none fill-grey forced-colors:fill-systemColors-CanvasText forced-colors:peer-checked:fill-systemColors-Highlight dark:fill-white peer-checked:fill-green-highlight dark:peer-checked:fill-greenDarkMode-highlight inline"
         >
           <use xlink:href="/icons/darkThemeIcon.svg#svg5"></use>
         </svg>
         <span
-          class="pl-1 font-bold forced-colors:peer-checked:text-systemColors-AccentColor peer-checked:text-green-base dark:peer-checked:text-greenDarkMode-base"
+          class="pl-1 font-bold forced-colors:peer-checked:text-systemColors-Highlight peer-checked:text-green-base dark:peer-checked:text-greenDarkMode-base"
         >
           Dark
         </span>

--- a/components/TimelineBadge.vue
+++ b/components/TimelineBadge.vue
@@ -6,7 +6,7 @@
       stroke-linecap="round"
       stroke-linejoin="round"
       stroke-width="6"
-      class="stroke-green-highlight dark:stroke-greenDarkMode-base h-7 tablet:h-8"
+      class="stroke-green-highlight forced-colors:stroke-systemColors-AccentColor dark:stroke-greenDarkMode-base h-7 tablet:h-8"
       :class="{ 'h-6 tablet:h-7': compact }"
       role="img"
     >

--- a/components/TimelineBadge.vue
+++ b/components/TimelineBadge.vue
@@ -6,7 +6,7 @@
       stroke-linecap="round"
       stroke-linejoin="round"
       stroke-width="6"
-      class="stroke-green-highlight forced-colors:stroke-systemColors-AccentColor dark:stroke-greenDarkMode-base h-7 tablet:h-8"
+      class="stroke-green-highlight forced-colors:stroke-systemColors-Highlight dark:stroke-greenDarkMode-base h-7 tablet:h-8"
       :class="{ 'h-6 tablet:h-7': compact }"
       role="img"
     >

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -8,7 +8,7 @@
         alt="Lucas Steer's Logo"
         height="48"
         width="48"
-        class="hidden h-12 w-12 tablet:block"
+        class="hidden h-12 w-12 tablet:block forced-colors:bg-systemColors-ButtonBorder forced-colors:rounded-full forced-colors:p-1"
       />
       <nav class="w-full">
         <ul class="flex flex-row justify-around">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
+const plugin = require('tailwindcss/plugin');
 
 module.exports = {
   content: [
@@ -68,6 +69,27 @@ module.exports = {
         baseLarge: '#3B94DE',
         highlight: '#9CCBF2',
         highlightLarge: '#5EA7E4',
+      },
+      systemColors: {
+        AccentColor: 'AccentColor',
+        AccentColorText: 'AccentColorText',
+        ActiveText: 'ActiveText',
+        ButtonBorder: 'ButtonBorder',
+        ButtonFace: 'ButtonFace',
+        ButtonText: 'ButtonText',
+        Canvas: 'Canvas',
+        CanvasText: 'CanvasText',
+        Field: 'Field',
+        FieldText: 'FieldText',
+        GrayText: 'GrayText',
+        Highlight: 'Highlight',
+        HighlightText: 'HighlightText',
+        LinkText: 'LinkText',
+        Mark: 'Mark',
+        MarkText: 'MarkText',
+        SelectedItem: 'SelectedItem',
+        SelectedItemText: 'SelectedItemText',
+        VisitedText: 'VisitedText',
       },
     }),
     columns: {
@@ -332,6 +354,7 @@ module.exports = {
       greenDarkMode: theme('colors.primaryDarkMode'),
       blue: theme('colors.links'),
       blueDarkMode: theme('colors.linksDarkMode'),
+      systemColors: theme('colors.systemColors'),
     }),
     grayscale: {
       0: '0',
@@ -861,6 +884,7 @@ module.exports = {
       greenDarkMode: theme('colors.primaryDarkMode'),
       blue: theme('colors.links'),
       blueDarkMode: theme('colors.linksDarkMode'),
+      systemColors: theme('colors.systemColors'),
     }),
     strokeWidth: {
       0: '0',
@@ -877,6 +901,7 @@ module.exports = {
       greenDarkMode: theme('colors.primaryDarkMode'),
       blue: theme('colors.links'),
       blueDarkMode: theme('colors.linksDarkMode'),
+      systemColors: theme('colors.systemColors'),
     }),
     textDecorationColor: ({ theme }) => theme('colors'),
     textDecorationThickness: {
@@ -1029,5 +1054,9 @@ module.exports = {
     'active',
     'disabled',
   ],
-  plugins: [],
+  plugins: [
+    plugin(({ addVariant }) => {
+      addVariant('forced-colors', '@media (forced-colors: active)');
+    }),
+  ],
 };


### PR DESCRIPTION
Provides support for WHCM. Note: needed to switch from `AccentColor` to `Highlight` because Chrome doesn't seem to recognize the `AccentColor` system-color. Going to investigate that some more, but for my purposes this switch works as needed